### PR TITLE
feat: extend validator keywords to include 'x-env-format'

### DIFF
--- a/src/configs/models/configValidator.ts
+++ b/src/configs/models/configValidator.ts
@@ -27,7 +27,7 @@ export class Validator {
         loadSchema: async (uri): Promise<AnySchemaObject> => {
           return this.schemaManager.getSchema(uri);
         },
-        keywords: ['x-env-value'],
+        keywords: ['x-env-value', 'x-env-format'],
         useDefaults: true,
       })
     );


### PR DESCRIPTION
Added support so ajv allowed the x-env-format keyword

related pull requests:
https://github.com/MapColonies/config-ui/pull/61
https://github.com/MapColonies/config/pull/59
https://github.com/MapColonies/schemas/pull/82