### PR TITLE
fix: add limit to the latest migration

### DIFF
--- a/src/db/migrations/0003_dry_leader.sql
+++ b/src/db/migrations/0003_dry_leader.sql
@@ -27,6 +27,8 @@ SET
       "config_server"."config" c
     WHERE
       c."name" = "config_refs"."name"
+    LIMIT
+      1
   );
 
 --> statement-breakpoint
@@ -39,6 +41,8 @@ SET
       "config_server"."config" c
     WHERE
       c."name" = "config_refs"."ref_name"
+    LIMIT
+      1
   );
 
 --> statement-breakpoint


### PR DESCRIPTION
Add a limit to the latest migration queries to ensure only one result is returned, improving performance and preventing potential issues with multiple results.