### PR TITLE
helm: remove environment

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -60,17 +60,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Returns the environment from global if exists or from the chart's values, defaults to development
-*/}}
-{{- define "config-server.environment" -}}
-{{- if .Values.global.environment }}
-    {{- .Values.global.environment -}}
-{{- else -}}
-    {{- .Values.environment | default "development" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Returns the cloud provider name from global if exists or from the chart's values, defaults to minikube
 */}}
 {{- define "config-server.cloudProviderFlavor" -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -13,7 +13,6 @@ metadata:
   labels:
     app: {{ $chartName }}
     component: {{ $chartName }}
-    environment: {{ include "config-server.environment" . }}
     release: {{ $releaseName }}
     {{- include "config-server.labels" . | nindent 4 }}
 spec:

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: {{ $chartName }}
     component: {{ $chartName }}
-    environment: {{ include "config-server.environment" . }}
     release: {{ $releaseName }}
     {{- include "config-server.labels" . | nindent 4 }}
 type: Opaque

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: {{ $chartName }}
     component: {{ $chartName }}
-    environment: {{ include "config-server.environment" . }}
     release: {{ $releaseName }}
     {{- include "config-server.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Eliminate the environment label from the Helm chart templates to simplify configuration management.